### PR TITLE
Preserve ffn and bt rendering for 0.1.11

### DIFF
--- a/klink/__init__.py
+++ b/klink/__init__.py
@@ -94,6 +94,6 @@ def setup(app):
     }
 
 
-VERSION = (0, 1, 10)
+VERSION = (0, 1, 11)
 __version__ = ".".join(str(v) for v in VERSION)
 __version_full__ = __version__

--- a/klink/layout.html
+++ b/klink/layout.html
@@ -1,8 +1,12 @@
 {%- extends "basic/layout.html" %}
     {%- block extrahead %}
         {{ super() }}
-        <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700" rel="stylesheet" type="text/css">
-        <link href="https://fonts.googleapis.com/css?family=Droid+Sans+Mono:400,500,700" rel="stylesheet" type="text/css">
+        <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
+        {% if favicon %}
+            <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1) }}">
+        {% endif %}
+        <link href='http://fonts.googleapis.com/css?family=Open+Sans:300,400,700' rel='stylesheet' type='text/css'>
+        <link href='http://fonts.googleapis.com/css?family=Droid+Sans+Mono:400,500,700' rel='stylesheet' type='text/css'>
     {% endblock %}
 
     {%- block relbar1 %}{% endblock %}
@@ -12,7 +16,7 @@
         <aside>
 
             {% if theme_logo %}
-            <a href="{{ pathto('index') }}" id="logo" title="{{ project|e }}"><img class="logo" src="{{ pathto('_static/' + theme_logo, 1) }}" width="150" height="150" alt="{{ project|e }}" /></a>
+            <a href="{{ pathto('index') }}" id="logo" title={{project}}><img class="logo" src="{{ pathto('_static/' + theme_logo, 1) }}" width="150px" height="150px" title={{project}} /></a>
             {% endif %}
             
             {{ toctree() }}

--- a/klink/less/klink.less
+++ b/klink/less/klink.less
@@ -370,16 +370,6 @@ div.pynb-result {
     table, p {
         margin-left: 20px;
     }
-
-    .highlight {
-        background: inherit;
-        border: none;
-
-        pre {
-            background: inherit;
-            border: none;
-        }
-    }
 }
 
 div#searchbox {

--- a/klink/static/css/klink.css
+++ b/klink/static/css/klink.css
@@ -2199,14 +2199,6 @@ div.pynb-result table,
 div.pynb-result p {
   margin-left: 20px;
 }
-div.pynb-result .highlight {
-  background: inherit;
-  border: none;
-}
-div.pynb-result .highlight pre {
-  background: inherit;
-  border: none;
-}
 div#searchbox {
   padding-top: 10px;
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "klink"
-version = "0.1.10"
+version = "0.1.11"
 description = "A simple and clean Sphinx theme inspired by jrnl"
 readme = "README.rst"
 license = "MIT"


### PR DESCRIPTION
Prepares Klink 0.1.11 after packaging modernization while preserving ffn and bt rendering.

- restores template markup used by both projects
- removes notebook-result CSS overrides absent from their vendored theme
- keeps LESS source and compiled CSS aligned
- bumps package version to 0.1.11

The CSS overrides removed 1 px borders around notebook output blocks. That shortened ffn by 2 px and bt by 6 px on representative index pages.

Compared ffn and bt index/API pages at desktop and mobile sizes with external requests disabled. All eight old/new screenshot pairs now have identical dimensions, SHA-256 values, and zero differing pixels.

Also checked `make lint`, wheel/sdist builds, Twine metadata, and warning-as-error documentation builds with Sphinx 7.4.7 and 9.1.0.
